### PR TITLE
Some Permissions refactoring

### DIFF
--- a/src/net/milkbowl/vault/permission/plugins/Permission_GroupManager.java
+++ b/src/net/milkbowl/vault/permission/plugins/Permission_GroupManager.java
@@ -3,8 +3,8 @@ package net.milkbowl.vault.permission.plugins;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.logging.Logger;
 
+import net.milkbowl.vault.Vault;
 import net.milkbowl.vault.permission.Permission;
 
 import org.anjocaido.groupmanager.GroupManager;
@@ -24,17 +24,15 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 
 public class Permission_GroupManager extends Permission {
-    private static final Logger log = Logger.getLogger("Minecraft");
 
     private String name = "GroupManager";
-    private Plugin plugin = null;
     private PluginManager pluginManager = null;
     private GroupManager groupManager;
     private AnjoPermissionsHandler perms;
     private PermissionServerListener permissionServerListener = null;
 
     @SuppressWarnings("deprecation")
-    public Permission_GroupManager(Plugin plugin) {
+    public Permission_GroupManager(Vault plugin) {
         this.plugin = plugin;
         pluginManager = this.plugin.getServer().getPluginManager();
 

--- a/src/net/milkbowl/vault/permission/plugins/Permission_Permissions3.java
+++ b/src/net/milkbowl/vault/permission/plugins/Permission_Permissions3.java
@@ -21,13 +21,10 @@ package net.milkbowl.vault.permission.plugins;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.logging.Logger;
 
 import net.milkbowl.vault.Vault;
 import net.milkbowl.vault.permission.Permission;
 
-import org.bukkit.Bukkit;
-import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event.Priority;
 import org.bukkit.event.Event.Type;
@@ -37,16 +34,13 @@ import org.bukkit.event.server.ServerListener;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 
-import com.nijiko.permissions.Group;
 import com.nijiko.permissions.PermissionHandler;
 import com.nijikokun.bukkit.Permissions.Permissions;
 
 public class Permission_Permissions3 extends Permission {
-    private static final Logger log = Logger.getLogger("Minecraft");
 
     private String name = "Permissions 3 (Yeti)";
     private PermissionHandler perms;
-    private Vault plugin = null;
     private PluginManager pluginManager = null;
     private Permissions permission = null;
     private PermissionServerListener permissionServerListener = null;

--- a/src/net/milkbowl/vault/permission/plugins/Permission_PermissionsBukkit.java
+++ b/src/net/milkbowl/vault/permission/plugins/Permission_PermissionsBukkit.java
@@ -2,18 +2,14 @@ package net.milkbowl.vault.permission.plugins;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
 
+import org.bukkit.Bukkit;
 import org.bukkit.command.ConsoleCommandSender;
-import org.bukkit.craftbukkit.command.ColouredConsoleSender;
-import org.bukkit.entity.Player;
 import org.bukkit.event.Event.Priority;
 import org.bukkit.event.Event.Type;
 import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.event.server.PluginEnableEvent;
 import org.bukkit.event.server.ServerListener;
-import org.bukkit.permissions.PermissionAttachment;
-import org.bukkit.permissions.PermissionAttachmentInfo;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 
@@ -21,29 +17,28 @@ import com.platymuus.bukkit.permissions.Group;
 import com.platymuus.bukkit.permissions.PermissionsPlugin;
 
 import net.D3GN.MiracleM4n.mChat.mChatAPI;
+import net.milkbowl.vault.Vault;
 import net.milkbowl.vault.permission.Permission;
 
 public class Permission_PermissionsBukkit extends Permission {
-	private static final Logger log = Logger.getLogger("Minecraft");
 
 	private final String name = "PermissionsBukkit";
-	private Plugin plugin = null;
 	private PluginManager pluginManager = null;
 	private PermissionsPlugin perms = null;
 	private mChatAPI mChat = null;
 	private PermissionServerListener permissionServerListener = null;
 	private ConsoleCommandSender ccs;
 
-	public Permission_PermissionsBukkit(Plugin plugin) {
+	public Permission_PermissionsBukkit(Vault plugin) {
 		this.plugin = plugin;
-		ccs = ColouredConsoleSender.getInstance();
+		ccs = Bukkit.getServer().getConsoleSender();
 		pluginManager = this.plugin.getServer().getPluginManager();
 
 		permissionServerListener = new PermissionServerListener(this);
 
 		this.pluginManager.registerEvent(Type.PLUGIN_ENABLE, permissionServerListener, Priority.Monitor, plugin);
 		this.pluginManager.registerEvent(Type.PLUGIN_DISABLE, permissionServerListener, Priority.Monitor, plugin);
-
+		
 		// Load Plugin in case it was loaded before
 		if (perms == null) {
 			Plugin perms = plugin.getServer().getPluginManager().getPlugin("PermissionsBukkit");
@@ -136,26 +131,6 @@ public class Permission_PermissionsBukkit extends Permission {
 	}
 
 	@Override
-	public boolean playerAddTransient(String world, String player, String permission) {
-		Player p = plugin.getServer().getPlayer(player);
-		if (p == null) {
-			throw new UnsupportedOperationException(getName() + " does not support offline player transient permissions!");
-		}
-
-		for (PermissionAttachmentInfo paInfo : p.getEffectivePermissions()) {
-			if (paInfo.getAttachment() != null && paInfo.getAttachment().getPlugin().equals(plugin)) {
-				paInfo.getAttachment().setPermission(permission, true);
-				return true;
-			}
-		}
-
-		PermissionAttachment attach = p.addAttachment(plugin);
-		attach.setPermission(permission, true);
-
-		return true;
-	}
-
-	@Override
 	public boolean playerRemove(String world, String player, String permission) {
 		if (world != null) {
 			permission = world + ":" + permission;
@@ -163,21 +138,8 @@ public class Permission_PermissionsBukkit extends Permission {
 		return plugin.getServer().dispatchCommand(ccs, "permissions player unsetperm " + player + " " + permission);
 	}
 
-	@Override
-	public boolean playerRemoveTransient(String world, String player, String permission) {
-		Player p = plugin.getServer().getPlayer(player);
-		if (p == null) {
-			throw new UnsupportedOperationException(getName() + " does not support offline player transient permissions!");
-		}
-		for (PermissionAttachmentInfo paInfo : p.getEffectivePermissions()) {
-			if (paInfo.getAttachment() != null && paInfo.getAttachment().getPlugin().equals(plugin)) {
-				paInfo.getAttachment().unsetPermission(permission);
-				return true;
-			}
-		}
-		return false;
-	}
-
+	// use superclass implementation of playerAddTransient() and playerRemoveTransient()
+	
 	@Override
 	public boolean groupHas(String world, String group, String permission) {
 		if (world != null && !world.isEmpty()) {

--- a/src/net/milkbowl/vault/permission/plugins/Permission_PermissionsEx.java
+++ b/src/net/milkbowl/vault/permission/plugins/Permission_PermissionsEx.java
@@ -19,8 +19,6 @@
 
 package net.milkbowl.vault.permission.plugins;
 
-import java.util.logging.Logger;
-
 import net.milkbowl.vault.Vault;
 import net.milkbowl.vault.permission.Permission;
 
@@ -38,10 +36,8 @@ import ru.tehkode.permissions.PermissionUser;
 import ru.tehkode.permissions.bukkit.PermissionsEx;
 
 public class Permission_PermissionsEx extends Permission {
-    private static final Logger log = Logger.getLogger("Minecraft");
 
     private final String name = "PermissionsEx";
-    private Vault plugin = null;
     private PluginManager pluginManager = null;
     private PermissionsEx permission = null;
     private PermissionServerListener permissionServerListener = null;

--- a/src/net/milkbowl/vault/permission/plugins/Permission_SuperPerms.java
+++ b/src/net/milkbowl/vault/permission/plugins/Permission_SuperPerms.java
@@ -1,8 +1,6 @@
 package net.milkbowl.vault.permission.plugins;
 
 import org.bukkit.entity.Player;
-import org.bukkit.permissions.PermissionAttachment;
-import org.bukkit.permissions.PermissionAttachmentInfo;
 
 import net.milkbowl.vault.Vault;
 import net.milkbowl.vault.permission.Permission;
@@ -37,41 +35,10 @@ public class Permission_SuperPerms extends Permission {
 		return false;
 	}
 
-	@Override
-	public boolean playerAddTransient(String world, String player, String permission) {
-		Player p = plugin.getServer().getPlayer(player);
-		if (p == null)
-			return false;
-		
-		for (PermissionAttachmentInfo paInfo : p.getEffectivePermissions()) {
-			if (paInfo.getAttachment().getPlugin().equals(plugin)) {
-				paInfo.getAttachment().setPermission(permission, true);
-				return true;
-			}
-		}
-		
-		PermissionAttachment attach = p.addAttachment(plugin);
-		attach.setPermission(permission, true);
-		
-		return true;
-	}
+	// use superclass implementation of playerAddTransient() and playerRemoveTransient()
 
 	@Override
 	public boolean playerRemove(String world, String player, String permission) {
-		return false;
-	}
-
-	@Override
-	public boolean playerRemoveTransient(String world, String player, String permission) {
-		Player p = plugin.getServer().getPlayer(player);
-		if (p == null)
-			return false;
-		
-		for (PermissionAttachmentInfo paInfo : p.getEffectivePermissions()) {
-			if (paInfo.getAttachment().getPlugin().equals(plugin)) {
-				return paInfo.getAttachment().getPermissions().remove(permission);
-			}
-		}
 		return false;
 	}
 

--- a/src/net/milkbowl/vault/permission/plugins/Permission_bPermissions.java
+++ b/src/net/milkbowl/vault/permission/plugins/Permission_bPermissions.java
@@ -1,7 +1,6 @@
 package net.milkbowl.vault.permission.plugins;
 
 import java.util.List;
-import java.util.logging.Logger;
 
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event.Priority;
@@ -9,8 +8,6 @@ import org.bukkit.event.Event.Type;
 import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.event.server.PluginEnableEvent;
 import org.bukkit.event.server.ServerListener;
-import org.bukkit.permissions.PermissionAttachment;
-import org.bukkit.permissions.PermissionAttachmentInfo;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 
@@ -22,10 +19,8 @@ import net.milkbowl.vault.Vault;
 import net.milkbowl.vault.permission.Permission;
 
 public class Permission_bPermissions extends Permission {
-	private static final Logger log = Logger.getLogger("Minecraft");
 
 	private String name = "bPermissions";
-	private Vault plugin = null;
 	private PluginManager pluginManager = null;
 	private WorldPermissionsManager perms;
 	private PermissionServerListener permissionServerListener = null;
@@ -96,43 +91,12 @@ public class Permission_bPermissions extends Permission {
 	}
 
 	@Override
-	public boolean playerAddTransient(String world, String player, String permission) {
-		Player p = plugin.getServer().getPlayer(player);
-		if (p == null)
-			return false;
-		
-		for (PermissionAttachmentInfo paInfo : p.getEffectivePermissions()) {
-			if (paInfo.getAttachment().getPlugin().equals(plugin)) {
-				paInfo.getAttachment().setPermission(permission, true);
-				return true;
-			}
-		}
-		
-		PermissionAttachment attach = p.addAttachment(plugin);
-		attach.setPermission(permission, true);
-		
-		return true;
-	}
-
-	@Override
 	public boolean playerRemove(String world, String player, String permission) {
 		throw new UnsupportedOperationException("Player specific permissions are not supported!");
 	}
 
-	@Override
-	public boolean playerRemoveTransient(String world, String player, String permission) {
-		Player p = plugin.getServer().getPlayer(player);
-		if (p == null)
-			return false;
-		
-		for (PermissionAttachmentInfo paInfo : p.getEffectivePermissions()) {
-			if (paInfo.getAttachment().getPlugin().equals(plugin)) {
-				return paInfo.getAttachment().getPermissions().remove(permission);
-			}
-		}
-		return false;
-	}
-
+	// use superclass implementation of playerAddTransient() and playerRemoveTransient()
+	
 	@Override
 	public boolean groupHas(String world, String group, String permission) {
 		if (world == null)


### PR DESCRIPTION
As discussed in my last pull request:
- Add default implementations of playerAddTransient() &
  playerRemoveTransient() to the Permissions superclass.  "Pure"
  superperms handlers (e.g. bPermissions, PermissionsBukkit) use those
  methods, while handlers which use their own API can override them.
- Moved log and plugin fields to the Permissions superclass, since
  they're present in all handlers.
