### PR TITLE
I stupidly inverted the parameters of my own API. This pull fixes that.

### DIFF
--- a/src/net/milkbowl/vault/permission/plugins/Permission_Privileges.java
+++ b/src/net/milkbowl/vault/permission/plugins/Permission_Privileges.java
@@ -103,13 +103,13 @@ public class Permission_Privileges extends Permission {
     @Override
     public boolean groupAdd(String world, String group, String permission) {
         Group g = privs.getGroupManager().getGroup(group);
-        return g != null && g.addPermission(permission, world);
+        return g != null && g.addPermission(world, permission);
     }
 
     @Override
     public boolean groupRemove(String world, String group, String permission) {
         Group g = privs.getGroupManager().getGroup(group);
-        return g != null && g.removePermission(permission, world);
+        return g != null && g.removePermission(world, permission);
     }
 
     @Override


### PR DESCRIPTION
Sorry about this. The jar doesn't appear to include the javadocs (like a normal maven repo), and I apparently forgot my own API.
