### PR TITLE
Compiler Warnings Fix (JavaDocs)

### DIFF
--- a/src/net/milkbowl/vault/economy/Economy.java
+++ b/src/net/milkbowl/vault/economy/Economy.java
@@ -98,7 +98,7 @@ public interface Economy {
      * 
      * @param playerName
      * @param amount
-     * @return
+     * @return True if <b>playerName</b> has <b>amount</b>, False else wise
      */
     public boolean has(String playerName, double amount);
     
@@ -124,7 +124,7 @@ public interface Economy {
      * Creates a bank account with the specified name and the player as the owner
      * @param name
      * @param player
-     * @return
+     * @return EconomyResponse Object
      */
     public EconomyResponse createBank(String name, String player);
 
@@ -138,7 +138,7 @@ public interface Economy {
     /**
      * Returns the amount the bank has
      * @param name
-     * @return
+     * @return EconomyResponse Object
      */
     public EconomyResponse bankBalance(String name);
 
@@ -147,7 +147,7 @@ public interface Economy {
      * 
      * @param name
      * @param amount
-     * @return
+     * @return EconomyResponse Object
      */
     public EconomyResponse bankHas(String name, double amount);
 
@@ -156,7 +156,7 @@ public interface Economy {
      * 
      * @param name
      * @param amount
-     * @return
+     * @return EconomyResponse Object
      */
     public EconomyResponse bankWithdraw(String name, double amount);
 
@@ -165,7 +165,7 @@ public interface Economy {
      * 
      * @param name
      * @param amount
-     * @return
+     * @return EconomyResponse Object
      */
     public EconomyResponse bankDeposit(String name, double amount);
 
@@ -173,7 +173,7 @@ public interface Economy {
      * Check if a player is the owner of a bank account
      * @param name
      * @param playerName
-     * @return
+     * @return EconomyResponse Object
      */
     public EconomyResponse isBankOwner(String name, String playerName);
 
@@ -181,7 +181,7 @@ public interface Economy {
      * Check if the player is a member of the bank account
      * @param name
      * @param playerName
-     * @return
+     * @return EconomyResponse Object
      */
     public EconomyResponse isBankMember(String name, String playerName);
 

--- a/src/net/milkbowl/vault/item/Items.java
+++ b/src/net/milkbowl/vault/item/Items.java
@@ -630,7 +630,7 @@ public class Items {
      * Single item search function, for when we only ever want to return 1 result
      *
      * @param searchString
-     * @return
+     * @return ItemInfo Object
      */
     public static ItemInfo itemByName(String searchString) {
         ItemInfo matchedItem = null;
@@ -706,7 +706,7 @@ public class Items {
      * Joins elements of a String array with the glue between them into a String.
      * @param array
      * @param glue
-     * @return
+     * @return Concacted Array combined with glue
      */
     public static String join(String[] array, String glue) {
         String joined = null;
@@ -729,7 +729,7 @@ public class Items {
      * Joins elements of a String array with the glue between them into a String.
      * @param list
      * @param glue
-     * @return
+     * @return Concacted Array combined with glue
      */
     public static String join(List<String> list, String glue) {
         String joined = null;


### PR DESCRIPTION
Fixed some warnings some ides would throw if people set javadoc warnings up. 

Return statements missing description warnings fixed. Only on 2 major files. The metrics file is not fixed due to it being a part of another repo.

Signed-off-by: coaster3000 ckrier.3000@gmail.com
