### PR TITLE
Make breaking change somewhat less breaking; add transfer methods to interface

### DIFF
--- a/src/net/milkbowl/vault/economy/AbstractEconomy.java
+++ b/src/net/milkbowl/vault/economy/AbstractEconomy.java
@@ -1,0 +1,55 @@
+package net.milkbowl.vault.economy;
+
+/**
+ * Abstract extension of the Economy interface, which offers implementation of several utility methods based on the supported primitives.
+ */
+public abstract class AbstractEconomy implements Economy {
+
+    /*
+     * (non-Javadoc)
+     * @see net.milkbowl.vault.economy.Economy#transfer(double, java.lang.String, java.lang.String)
+     */
+    public EconomyResponse transfer(double amount, String playerFrom, String playerTo) {
+        EconomyResponse w = withdrawPlayer(playerFrom, amount);
+        if (w.transactionSuccess()) {
+            EconomyResponse d = depositPlayer(playerTo, amount);
+            if ( ! d.transactionSuccess()) {
+                depositPlayer(playerFrom, amount);
+            }
+            return d;
+        }
+        return w;
+    }
+    
+    /*
+     * (non-Javadoc)
+     * @see net.milkbowl.vault.economy.Economy#transferPlayerToBank(double, java.lang.String, java.lang.String)
+     */
+    public EconomyResponse transferPlayerToBank(double amount, String playerFrom, String bankTo) {
+        EconomyResponse w = withdrawPlayer(playerFrom, amount);
+        if (w.transactionSuccess()) {
+            EconomyResponse d = bankDeposit(playerFrom, amount);
+            if ( ! d.transactionSuccess()) {
+                depositPlayer(playerFrom, amount);
+            }
+            return d;
+        }
+        return w;
+    }
+    
+    /* 
+     * (non-Javadoc)
+     * @see net.milkbowl.vault.economy.Economy#transferBankToPlayer(double, java.lang.String, java.lang.String)
+     */
+    public EconomyResponse transferBankToPlayer(double amount, String bankFrom, String playerTo) {
+        EconomyResponse w = bankWithdraw(bankFrom, amount);
+        if (w.transactionSuccess()) {
+            EconomyResponse d = depositPlayer(playerTo, amount);
+            if ( ! d.transactionSuccess()) {
+                depositPlayer(bankFrom, amount);
+            }
+            return d;
+        }
+        return w;
+    }
+}

--- a/src/net/milkbowl/vault/economy/Economy.java
+++ b/src/net/milkbowl/vault/economy/Economy.java
@@ -22,7 +22,7 @@ import java.util.List;
  * The main economy API
  *
  */
-public abstract class Economy {
+public interface Economy {
 
     /**
      * Checks if economy method is enabled.
@@ -196,4 +196,44 @@ public abstract class Economy {
      * @return if the account creation was successful
      */
     public abstract boolean createPlayerAccount(String playerName);
+    
+    /**
+     * Transfer an amount of money from one player to another.
+     * This action withdraws the amount from the sender, and deposits it to the recipient's account.
+     * If either the withdrawal or the deposit fails, the transaction as a whole also fails.
+     * This means that both the sender and the recipient's account balance remains unchanged.
+     * 
+     * @param amount amount of money to transfer
+     * @param playerFrom player to withdraw from
+     * @param playerTo player to deposit to
+     * @return transaction success information
+     */
+    public EconomyResponse transfer(double amount, String playerFrom, String playerTo);
+    
+    /**
+     * Transfer an amount of money from a player to a bank account.
+     * This action withdraws the amount from the sender, and deposits it to the recipient's account.
+     * If either the withdrawal or the deposit fails, the transaction as a whole also fails.
+     * This means that both the sender and the recipient's account balance remains unchanged.
+     * 
+     * @param amount amount of money to transfer
+     * @param playerFrom player to withdraw from
+     * @param bankTo bank to deposit to
+     * @return transaction success information
+     */
+    public EconomyResponse transferPlayerToBank(double amount, String playerFrom, String bankTo);
+    
+    /**
+     * Transfer an amount of money from a bank to a player.
+     * This action withdraws the amount from the sender, and deposits it to the recipient's account.
+     * If either the withdrawal or the deposit fails, the transaction as a whole also fails.
+     * This means that both the sender and the recipient's account balance remains unchanged.
+     * 
+     * @param amount amount of money to transfer
+     * @param bankFrom player to withdraw from
+     * @param playerTo player to deposit to
+     * @return transaction success information
+     */
+    public EconomyResponse transferBankToPlayer(double amount, String bankFrom, String playerTo);
+
 }

--- a/src/net/milkbowl/vault/economy/plugins/Economy_3co.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_3co.java
@@ -21,7 +21,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import me.ic3d.eco.ECO;
-import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.AbstractEconomy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 
@@ -34,7 +34,7 @@ import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.event.server.PluginEnableEvent;
 import org.bukkit.plugin.Plugin;
 
-public class Economy_3co extends Economy {
+public class Economy_3co extends AbstractEconomy {
     private static final Logger log = Logger.getLogger("Minecraft");
 
     private final String name = "3co";

--- a/src/net/milkbowl/vault/economy/plugins/Economy_AEco.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_AEco.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.AbstractEconomy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 
@@ -35,7 +35,7 @@ import org.bukkit.event.server.PluginEnableEvent;
 import org.bukkit.plugin.Plugin;
 import org.neocraft.AEco.AEco;
 
-public class Economy_AEco extends Economy {
+public class Economy_AEco extends AbstractEconomy {
     private static final Logger log = Logger.getLogger("Minecraft");
 
     private final String name = "AEco";

--- a/src/net/milkbowl/vault/economy/plugins/Economy_BOSE6.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_BOSE6.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.AbstractEconomy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 
@@ -34,7 +34,7 @@ import org.bukkit.plugin.Plugin;
 import cosine.boseconomy.BOSEconomy;
 
 @SuppressWarnings("deprecation")
-public class Economy_BOSE6 extends Economy {
+public class Economy_BOSE6 extends AbstractEconomy {
     private static final Logger log = Logger.getLogger("Minecraft");
 
     private final String name = "BOSEconomy";

--- a/src/net/milkbowl/vault/economy/plugins/Economy_BOSE7.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_BOSE7.java
@@ -18,7 +18,7 @@ package net.milkbowl.vault.economy.plugins;
 import java.util.List;
 import java.util.logging.Logger;
 
-import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.AbstractEconomy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 
@@ -32,7 +32,7 @@ import org.bukkit.plugin.Plugin;
 
 import cosine.boseconomy.BOSEconomy;
 
-public class Economy_BOSE7 extends Economy {
+public class Economy_BOSE7 extends AbstractEconomy {
     private static final Logger log = Logger.getLogger("Minecraft");
 
     private final String name = "BOSEconomy";

--- a/src/net/milkbowl/vault/economy/plugins/Economy_CommandsEX.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_CommandsEX.java
@@ -15,10 +15,11 @@ import org.bukkit.plugin.Plugin;
 import com.github.zathrus_writer.commandsex.CommandsEX;
 import com.github.zathrus_writer.commandsex.api.economy.Economy;
 
+import net.milkbowl.vault.economy.AbstractEconomy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 
-public class Economy_CommandsEX extends net.milkbowl.vault.economy.Economy {
+public class Economy_CommandsEX extends AbstractEconomy {
 	private static final Logger log = Logger.getLogger("Minecraft");
 	
 	private final String name = "CommandsEX Economy";

--- a/src/net/milkbowl/vault/economy/plugins/Economy_Craftconomy.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_Craftconomy.java
@@ -26,7 +26,7 @@ import me.greatman.Craftconomy.BankHandler;
 import me.greatman.Craftconomy.Craftconomy;
 import me.greatman.Craftconomy.CurrencyHandler;
 import me.greatman.Craftconomy.utils.Config;
-import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.AbstractEconomy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 
@@ -38,7 +38,7 @@ import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.event.server.PluginEnableEvent;
 import org.bukkit.plugin.Plugin;
 
-public class Economy_Craftconomy extends Economy {
+public class Economy_Craftconomy extends AbstractEconomy {
     private static final Logger log = Logger.getLogger("Minecraft");
 
     private final String name = "Craftconomy";

--- a/src/net/milkbowl/vault/economy/plugins/Economy_Craftconomy3.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_Craftconomy3.java
@@ -20,7 +20,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Logger;
 
-import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.AbstractEconomy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 
@@ -38,7 +38,7 @@ import com.greatmancode.craftconomy3.account.Account;
 import com.greatmancode.craftconomy3.currency.CurrencyManager;
 import com.greatmancode.craftconomy3.database.tables.AccountTable;
 
-public class Economy_Craftconomy3 extends Economy {
+public class Economy_Craftconomy3 extends AbstractEconomy {
 	private static final Logger log = Logger.getLogger("Minecraft");
 
 	private final String name = "Craftconomy3";

--- a/src/net/milkbowl/vault/economy/plugins/Economy_CurrencyCore.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_CurrencyCore.java
@@ -21,7 +21,7 @@ import is.currency.syst.AccountContext;
 import java.util.List;
 import java.util.logging.Logger;
 
-import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.AbstractEconomy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 
@@ -33,7 +33,7 @@ import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.event.server.PluginEnableEvent;
 import org.bukkit.plugin.Plugin;
 
-public class Economy_CurrencyCore extends Economy {
+public class Economy_CurrencyCore extends AbstractEconomy {
 
     private Currency currency;
     private static final Logger log = Logger.getLogger("Minecraft");

--- a/src/net/milkbowl/vault/economy/plugins/Economy_Dosh.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_Dosh.java
@@ -17,16 +17,16 @@ package net.milkbowl.vault.economy.plugins;
 
 import java.util.List;
 
+import net.milkbowl.vault.economy.AbstractEconomy;
+import net.milkbowl.vault.economy.EconomyResponse;
+
 import org.bukkit.plugin.Plugin;
 
 import com.gravypod.Dosh.Dosh;
 import com.gravypod.Dosh.MoneyUtils;
 
-import net.milkbowl.vault.economy.Economy;
-import net.milkbowl.vault.economy.EconomyResponse;
 
-
-public class Economy_Dosh extends Economy {
+public class Economy_Dosh extends AbstractEconomy {
 	
 	
 	Plugin plugin;

--- a/src/net/milkbowl/vault/economy/plugins/Economy_EconXP.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_EconXP.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.AbstractEconomy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 
@@ -35,7 +35,7 @@ import org.bukkit.plugin.Plugin;
 
 import ca.agnate.EconXP.EconXP;
 
-public class Economy_EconXP extends Economy {
+public class Economy_EconXP extends AbstractEconomy {
     private static final Logger log = Logger.getLogger("Minecraft");
 
     private final String name = "EconXP";

--- a/src/net/milkbowl/vault/economy/plugins/Economy_Essentials.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_Essentials.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
-import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.AbstractEconomy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 
@@ -35,7 +35,7 @@ import com.earth2me.essentials.Essentials;
 import com.earth2me.essentials.api.NoLoanPermittedException;
 import com.earth2me.essentials.api.UserDoesNotExistException;
 
-public class Economy_Essentials extends Economy {
+public class Economy_Essentials extends AbstractEconomy {
     private static final Logger log = Logger.getLogger("Minecraft");
 
     private final String name = "Essentials Economy";

--- a/src/net/milkbowl/vault/economy/plugins/Economy_GoldIsMoney.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_GoldIsMoney.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
-import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.AbstractEconomy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 
@@ -33,7 +33,7 @@ import org.bukkit.plugin.Plugin;
 
 import com.flobi.GoldIsMoney.GoldIsMoney;
 
-public class Economy_GoldIsMoney extends Economy {
+public class Economy_GoldIsMoney extends AbstractEconomy {
 	private static final Logger log = Logger.getLogger("Minecraft");
 	
 	private final String name = "GoldIsMoney";

--- a/src/net/milkbowl/vault/economy/plugins/Economy_GoldIsMoney2.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_GoldIsMoney2.java
@@ -18,7 +18,7 @@ package net.milkbowl.vault.economy.plugins;
 import java.util.List;
 import java.util.logging.Logger;
 
-import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.AbstractEconomy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 
@@ -32,7 +32,7 @@ import org.bukkit.plugin.Plugin;
 
 import com.flobi.GoldIsMoney2.GoldIsMoney;
 
-public class Economy_GoldIsMoney2 extends Economy {
+public class Economy_GoldIsMoney2 extends AbstractEconomy {
 	private static final Logger log = Logger.getLogger("Minecraft");
 	
 	private final String name = "GoldIsMoney";

--- a/src/net/milkbowl/vault/economy/plugins/Economy_Gringotts.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_Gringotts.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
-import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.AbstractEconomy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 
@@ -34,7 +34,7 @@ import org.gestern.gringotts.Account;
 import org.gestern.gringotts.AccountHolder;
 import org.gestern.gringotts.Gringotts;
 
-public class Economy_Gringotts extends Economy {
+public class Economy_Gringotts extends AbstractEconomy {
 
     private static final Logger log = Logger.getLogger("Minecraft");
 

--- a/src/net/milkbowl/vault/economy/plugins/Economy_McMoney.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_McMoney.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
-import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.AbstractEconomy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 
@@ -33,7 +33,7 @@ import org.bukkit.plugin.Plugin;
 
 import boardinggamer.mcmoney.McMoneyAPI;
 
-public class Economy_McMoney extends Economy {
+public class Economy_McMoney extends AbstractEconomy {
     private static final Logger log = Logger.getLogger("Minecraft");
 
     private final String name = "McMoney";

--- a/src/net/milkbowl/vault/economy/plugins/Economy_MineConomy.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_MineConomy.java
@@ -24,7 +24,7 @@ import me.mjolnir.mineconomy.exceptions.AccountNameConflictException;
 import me.mjolnir.mineconomy.exceptions.NoAccountException;
 import me.mjolnir.mineconomy.internal.MCCom;
 import me.mjolnir.mineconomy.internal.util.MCFormat;
-import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.AbstractEconomy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 
@@ -36,7 +36,7 @@ import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.event.server.PluginEnableEvent;
 import org.bukkit.plugin.Plugin;
 
-public class Economy_MineConomy extends Economy {
+public class Economy_MineConomy extends AbstractEconomy {
     private static final Logger log = Logger.getLogger("Minecraft");
 
     private final String name = "MineConomy";

--- a/src/net/milkbowl/vault/economy/plugins/Economy_MultiCurrency.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_MultiCurrency.java
@@ -21,7 +21,7 @@ import java.util.logging.Logger;
 
 import me.ashtheking.currency.Currency;
 import me.ashtheking.currency.CurrencyList;
-import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.AbstractEconomy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 
@@ -33,7 +33,7 @@ import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.event.server.PluginEnableEvent;
 import org.bukkit.plugin.Plugin;
 
-public class Economy_MultiCurrency extends Economy {
+public class Economy_MultiCurrency extends AbstractEconomy {
     private static final Logger log = Logger.getLogger("Minecraft");
 
     private final String name = "MultiCurrency";

--- a/src/net/milkbowl/vault/economy/plugins/Economy_SDFEconomy.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_SDFEconomy.java
@@ -18,20 +18,20 @@ package net.milkbowl.vault.economy.plugins;
 import java.util.List;
 import java.util.logging.Logger;
 
-import org.bukkit.plugin.Plugin;
+import net.milkbowl.vault.economy.AbstractEconomy;
+import net.milkbowl.vault.economy.EconomyResponse;
+
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.event.server.PluginEnableEvent;
+import org.bukkit.plugin.Plugin;
 
 import com.github.omwah.SDFEconomy.SDFEconomy;
 import com.github.omwah.SDFEconomy.SDFEconomyAPI;
 
-import net.milkbowl.vault.economy.Economy;
-import net.milkbowl.vault.economy.EconomyResponse;
-
-public class Economy_SDFEconomy extends Economy {
+public class Economy_SDFEconomy extends AbstractEconomy {
     private static final Logger log = Logger.getLogger("Minecraft");
     private Plugin plugin = null;
 

--- a/src/net/milkbowl/vault/economy/plugins/Economy_XPBank.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_XPBank.java
@@ -19,7 +19,7 @@ package net.milkbowl.vault.economy.plugins;
 import java.util.List;
 import java.util.logging.Logger;
 
-import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.AbstractEconomy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 
@@ -36,7 +36,7 @@ import com.gmail.mirelatrue.xpbank.Account;
 import com.gmail.mirelatrue.xpbank.GroupBank;
 import com.gmail.mirelatrue.xpbank.XPBank;
 
-public class Economy_XPBank extends Economy {
+public class Economy_XPBank extends AbstractEconomy {
     private static final Logger log = Logger.getLogger("Minecraft");
 
 

--- a/src/net/milkbowl/vault/economy/plugins/Economy_eWallet.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_eWallet.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.logging.Logger;
 
 import me.ethan.eWallet.ECO;
-import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.AbstractEconomy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 
@@ -32,7 +32,7 @@ import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.event.server.PluginEnableEvent;
 import org.bukkit.plugin.Plugin;
 
-public class Economy_eWallet extends Economy {
+public class Economy_eWallet extends AbstractEconomy {
     private static final Logger log = Logger.getLogger("Minecraft");
 
     private final String name = "eWallet";

--- a/src/net/milkbowl/vault/economy/plugins/Economy_iConomy4.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_iConomy4.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.AbstractEconomy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 
@@ -35,7 +35,7 @@ import org.bukkit.plugin.Plugin;
 import com.nijiko.coelho.iConomy.iConomy;
 import com.nijiko.coelho.iConomy.system.Account;
 
-public class Economy_iConomy4 extends Economy {
+public class Economy_iConomy4 extends AbstractEconomy {
     private static final Logger log = Logger.getLogger("Minecraft");
 
     private final String name = "iConomy 4";

--- a/src/net/milkbowl/vault/economy/plugins/Economy_iConomy5.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_iConomy5.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
-import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.AbstractEconomy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 
@@ -35,7 +35,7 @@ import com.iConomy.iConomy;
 import com.iConomy.system.Holdings;
 import com.iConomy.util.Constants;
 
-public class Economy_iConomy5 extends Economy {
+public class Economy_iConomy5 extends AbstractEconomy {
     private static final Logger log = Logger.getLogger("Minecraft");
 
     private final String name = "iConomy 5";

--- a/src/net/milkbowl/vault/economy/plugins/Economy_iConomy6.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_iConomy6.java
@@ -18,7 +18,7 @@ package net.milkbowl.vault.economy.plugins;
 import java.util.List;
 import java.util.logging.Logger;
 
-import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.AbstractEconomy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 
@@ -35,7 +35,7 @@ import com.iCo6.iConomy;
 import com.iCo6.system.Accounts;
 import com.iCo6.system.Holdings;
 
-public class Economy_iConomy6 extends Economy {
+public class Economy_iConomy6 extends AbstractEconomy {
     private static final Logger log = Logger.getLogger("Minecraft");
 
     private String name = "iConomy ";


### PR DESCRIPTION
Changing the Economy class to an abstract class broke all the plugins requesting the Economy interface.
This commit reverts it back to an interface, and adds the AbstractEconomy class instead.
This allows adding utility methods to the interface while maintaining backward compatibility.

Additionally, add 3 transfer methods to the interface for the most common money transfer use cases. These are implemented in the abstract class.

```
EconomyResponse transfer(double amount, String playerFrom, String playerTo)
EconomyResponse transferPlayerToBank(double amount, String playerFrom, String bankTo)
EconomyResponse transferBankToPlayer(double amount, String bankFrom, String playerTo) {
```
