### PR TITLE
zPermissions: Return empty string instead of null when prefix/suffix is unset

### DIFF
--- a/src/net/milkbowl/vault/chat/plugins/Chat_zPermissions.java
+++ b/src/net/milkbowl/vault/chat/plugins/Chat_zPermissions.java
@@ -89,7 +89,7 @@ public class Chat_zPermissions extends Chat {
 
     @Override
     public String getPlayerPrefix(String world, String player) {
-        return service.getPlayerMetadata(player, "prefix", String.class);
+        return getPlayerInfoString(world, player, "prefix", "");
     }
 
     @Override
@@ -99,7 +99,7 @@ public class Chat_zPermissions extends Chat {
 
     @Override
     public String getPlayerSuffix(String world, String player) {
-        return service.getPlayerMetadata(player, "suffix", String.class);
+        return getPlayerInfoString(world, player, "suffix", "");
     }
 
     @Override
@@ -109,7 +109,7 @@ public class Chat_zPermissions extends Chat {
 
     @Override
     public String getGroupPrefix(String world, String group) {
-        return service.getGroupMetadata(group, "prefix", String.class);
+        return getGroupInfoString(world, group, "prefix", "");
     }
 
     @Override
@@ -119,7 +119,7 @@ public class Chat_zPermissions extends Chat {
 
     @Override
     public String getGroupSuffix(String world, String group) {
-        return service.getGroupMetadata(group, "suffix", String.class);
+        return getGroupInfoString(world, group, "suffix", "");
     }
 
     @Override


### PR DESCRIPTION
I've been doing my testing of the zPerms/Vault chat interface with Herochat, but apparently there are chat plugins that choke when getPlayerPrefix() etc. return null.

I wasn't originally sure whether null was a valid return value for Vault Chat API methods. But I think I'll play it safe and never return null for prefix/suffix. (I can't make that change on my side since null means the metadata/info node is unset, vs. set as empty string.)

Anyway, thanks again!
