### PR TITLE
More zPermissions fixes

### DIFF
--- a/src/net/milkbowl/vault/chat/plugins/Chat_zPermissions.java
+++ b/src/net/milkbowl/vault/chat/plugins/Chat_zPermissions.java
@@ -21,7 +21,6 @@ import net.milkbowl.vault.chat.Chat;
 import net.milkbowl.vault.permission.Permission;
 
 import org.bukkit.Bukkit;
-import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -40,12 +39,9 @@ public class Chat_zPermissions extends Chat {
 
     private ZPermissionsService service;
 
-    private final ConsoleCommandSender ccs;
-
     public Chat_zPermissions(Plugin plugin, Permission perms) {
         super(perms);
         this.plugin = plugin;
-        ccs = Bukkit.getServer().getConsoleSender();
         Bukkit.getServer().getPluginManager().registerEvents(new PermissionServerListener(), plugin);
         // Load service in case it was loaded before
         if (service == null) {
@@ -94,7 +90,7 @@ public class Chat_zPermissions extends Chat {
 
     @Override
     public void setPlayerPrefix(String world, String player, String prefix) {
-        plugin.getServer().dispatchCommand(ccs, "permissions player " + player + " metadata set prefix " + prefix);
+        setPlayerInfoString(world, player, "prefix", prefix);
     }
 
     @Override
@@ -104,7 +100,7 @@ public class Chat_zPermissions extends Chat {
 
     @Override
     public void setPlayerSuffix(String world, String player, String suffix) {
-        plugin.getServer().dispatchCommand(ccs, "permissions player " + player + " metadata set suffix " + suffix);
+        setPlayerInfoString(world, player, "suffix", suffix);
     }
 
     @Override
@@ -114,7 +110,7 @@ public class Chat_zPermissions extends Chat {
 
     @Override
     public void setGroupPrefix(String world, String group, String prefix) {
-        plugin.getServer().dispatchCommand(ccs, "permissions group " + group + " metadata set prefix " + prefix);
+        setGroupInfoString(world, group, "prefix", prefix);
     }
 
     @Override
@@ -124,7 +120,7 @@ public class Chat_zPermissions extends Chat {
 
     @Override
     public void setGroupSuffix(String world, String group, String suffix) {
-        plugin.getServer().dispatchCommand(ccs, "permissions group " + group + " metadata set suffix " + suffix);
+        setGroupInfoString(world, group, "suffix", suffix);
     }
 
     @Override
@@ -138,7 +134,7 @@ public class Chat_zPermissions extends Chat {
 
     @Override
     public void setPlayerInfoInteger(String world, String player, String node, int value) {
-        plugin.getServer().dispatchCommand(ccs, "permissions player " + player + " metadata setint " + node + " " + value);
+        plugin.getServer().dispatchCommand(plugin.getServer().getConsoleSender(), "permissions player " + player + " metadata setint " + node + " " + value);
     }
 
     @Override
@@ -152,7 +148,7 @@ public class Chat_zPermissions extends Chat {
 
     @Override
     public void setGroupInfoInteger(String world, String group, String node, int value) {
-        plugin.getServer().dispatchCommand(ccs, "permissions group " + group + " metadata setint " + node + " " + value);
+        plugin.getServer().dispatchCommand(plugin.getServer().getConsoleSender(), "permissions group " + group + " metadata setint " + node + " " + value);
     }
 
     @Override
@@ -166,7 +162,7 @@ public class Chat_zPermissions extends Chat {
 
     @Override
     public void setPlayerInfoDouble(String world, String player, String node, double value) {
-        plugin.getServer().dispatchCommand(ccs, "permissions player " + player + " metadata setreal " + node + " " + value);
+        plugin.getServer().dispatchCommand(plugin.getServer().getConsoleSender(), "permissions player " + player + " metadata setreal " + node + " " + value);
     }
 
     @Override
@@ -180,7 +176,7 @@ public class Chat_zPermissions extends Chat {
 
     @Override
     public void setGroupInfoDouble(String world, String group, String node, double value) {
-        plugin.getServer().dispatchCommand(ccs, "permissions group " + group + " metadata setreal " + node + " " + value);
+        plugin.getServer().dispatchCommand(plugin.getServer().getConsoleSender(), "permissions group " + group + " metadata setreal " + node + " " + value);
     }
 
     @Override
@@ -194,7 +190,7 @@ public class Chat_zPermissions extends Chat {
 
     @Override
     public void setPlayerInfoBoolean(String world, String player, String node, boolean value) {
-        plugin.getServer().dispatchCommand(ccs, "permissions player " + player + " metadata setbool " + node + " " + value);
+        plugin.getServer().dispatchCommand(plugin.getServer().getConsoleSender(), "permissions player " + player + " metadata setbool " + node + " " + value);
     }
 
     @Override
@@ -208,7 +204,7 @@ public class Chat_zPermissions extends Chat {
 
     @Override
     public void setGroupInfoBoolean(String world, String group, String node, boolean value) {
-        plugin.getServer().dispatchCommand(ccs, "permissions group " + group + " metadata setbool " + node + " " + value);
+        plugin.getServer().dispatchCommand(plugin.getServer().getConsoleSender(), "permissions group " + group + " metadata setbool " + node + " " + value);
     }
 
     @Override
@@ -222,7 +218,7 @@ public class Chat_zPermissions extends Chat {
 
     @Override
     public void setPlayerInfoString(String world, String player, String node, String value) {
-        plugin.getServer().dispatchCommand(ccs, "permissions player " + player + " metadata set " + node + " " + value);
+        plugin.getServer().dispatchCommand(plugin.getServer().getConsoleSender(), "permissions player " + player + " metadata set " + node + " " + quote(value));
     }
 
     @Override
@@ -236,7 +232,15 @@ public class Chat_zPermissions extends Chat {
 
     @Override
     public void setGroupInfoString(String world, String group, String node, String value) {
-        plugin.getServer().dispatchCommand(ccs, "permissions group " + group + " metadata set " + node + " " + value);
+        plugin.getServer().dispatchCommand(plugin.getServer().getConsoleSender(), "permissions group " + group + " metadata set " + node + " " + quote(value));
+    }
+
+    private String quote(String input) {
+        input = input.replaceAll("\\\\", "\\\\\\\\").replaceAll("\"", "\\\\\"");
+        if (input.matches(".*\\s.*"))
+            return "\"" + input + "\""; // Enclose in quotes
+        else
+            return input;
     }
 
 }

--- a/src/net/milkbowl/vault/permission/plugins/Permission_zPermissions.java
+++ b/src/net/milkbowl/vault/permission/plugins/Permission_zPermissions.java
@@ -25,7 +25,6 @@ import net.milkbowl.vault.permission.Permission;
 
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -41,12 +40,10 @@ public class Permission_zPermissions extends Permission {
 
     private final String name = "zPermissions";
     private ZPermissionsService service;
-    private final ConsoleCommandSender ccs;
     private boolean trackSupport;
 
     public Permission_zPermissions(Plugin plugin) {
         this.plugin = plugin;
-        ccs = Bukkit.getServer().getConsoleSender();
         Bukkit.getServer().getPluginManager().registerEvents(new PermissionServerListener(), plugin);
         // Load service in case it was loaded before
         if (service == null) {
@@ -124,7 +121,7 @@ public class Permission_zPermissions extends Permission {
         if (world != null) {
             permission = world + ":" + permission;
         }
-        return plugin.getServer().dispatchCommand(ccs, "permissions player " + player + " set " + permission);
+        return plugin.getServer().dispatchCommand(plugin.getServer().getConsoleSender(), "permissions player " + player + " set " + permission);
     }
 
     @Override
@@ -132,7 +129,7 @@ public class Permission_zPermissions extends Permission {
         if (world != null) {
             permission = world + ":" + permission;
         }
-        return plugin.getServer().dispatchCommand(ccs, "permissions player " + player + " unset " + permission);
+        return plugin.getServer().dispatchCommand(plugin.getServer().getConsoleSender(), "permissions player " + player + " unset " + permission);
     }
 
     @Override
@@ -156,7 +153,7 @@ public class Permission_zPermissions extends Permission {
         if (world != null) {
             permission = world + ":" + permission;
         }
-        return plugin.getServer().dispatchCommand(ccs, "permissions group " + group + " set " + permission);
+        return plugin.getServer().dispatchCommand(plugin.getServer().getConsoleSender(), "permissions group " + group + " set " + permission);
     }
 
     @Override
@@ -164,7 +161,7 @@ public class Permission_zPermissions extends Permission {
         if (world != null) {
             permission = world + ":" + permission;
         }
-        return plugin.getServer().dispatchCommand(ccs, "permissions group " + group + " unset " + permission);
+        return plugin.getServer().dispatchCommand(plugin.getServer().getConsoleSender(), "permissions group " + group + " unset " + permission);
     }
 
     @Override
@@ -181,18 +178,12 @@ public class Permission_zPermissions extends Permission {
 
     @Override
     public boolean playerAddGroup(String world, String player, String group) {
-        if (world != null) {
-            return false;
-        }
-        return plugin.getServer().dispatchCommand(ccs, "permissions group " + group + " add " + player);
+        return plugin.getServer().dispatchCommand(plugin.getServer().getConsoleSender(), "permissions group " + group + " add " + player);
     }
 
     @Override
     public boolean playerRemoveGroup(String world, String player, String group) {
-        if (world != null) {
-            return false;
-        }
-        return plugin.getServer().dispatchCommand(ccs, "permissions group " + group + " remove " + player);
+        return plugin.getServer().dispatchCommand(plugin.getServer().getConsoleSender(), "permissions group " + group + " remove " + player);
     }
 
     @Override


### PR DESCRIPTION
-   Ignores world argument for playerAddGroup/playerRemoveGroup (since groups are not world-specific) rather than failing immediately
-   Properly quote prefix/suffix/string infos when setting.
-   Don't cache ConsoleCommandSender since it appears to be null at startup.

Thanks!
