### PR TITLE
Fix - worlds playersetgroup/remove

### DIFF
--- a/src/net/milkbowl/vault/permission/plugins/Permission_PermissionsEx.java
+++ b/src/net/milkbowl/vault/permission/plugins/Permission_PermissionsEx.java
@@ -121,14 +121,22 @@ public class Permission_PermissionsEx extends Permission {
         if (group == null || user == null) {
             return false;
         } else {
-            user.addGroup(groupName, worldName);
+        	if(worldName == null){
+                user.addGroup(groupName);
+        	}else{
+                user.addGroup(groupName, worldName);
+        	}
             return true;
         }
     }
 
     @Override
     public boolean playerRemoveGroup(String worldName, String playerName, String groupName) {
-        PermissionsEx.getPermissionManager().getUser(playerName).removeGroup(groupName, worldName);
+    	if(worldName == null){
+            PermissionsEx.getPermissionManager().getUser(playerName).removeGroup(groupName);
+    	}else{
+            PermissionsEx.getPermissionManager().getUser(playerName).removeGroup(groupName, worldName);
+    	}
         return true;
     }
 


### PR DESCRIPTION
When it's setting group when null is not checked, sets player world that he is at this moment, so its unposibble to set group for all
worlds.
