### PR TITLE
Fix incorrect version info

### DIFF
--- a/src/net/milkbowl/vault/Vault.java
+++ b/src/net/milkbowl/vault/Vault.java
@@ -584,7 +584,7 @@ public class Vault extends JavaPlugin {
             if (perms.has(player, "vault.update")) {
                 try {
                     if (newVersion > currentVersion) {
-                        player.sendMessage("Vault " +  newVersion + " is out! You are running " + currentVersion);
+                        player.sendMessage("Vault " +  newVersionTitle + " is out! You are running " + currentVersionTitle);
                         player.sendMessage("Update Vault at: http://dev.bukkit.org/server-mods/vault");
                     }
                 } catch (Exception e) {


### PR DESCRIPTION
Change the version as double to the version as string in chat when player joins the server. This will correct information like:
"Vault 15.6 is out! You are running 15.5" and change it to "Vault 1.5.6 is out! You are running 1.5.5".
Fixes issue #621: Missing dot in update checker.