### PR TITLE
Update bstats version to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@ Vault currently supports the following: Permissions 3, PEX, GroupManager, bPerms
 		<dependency>
 			<groupId>org.bstats</groupId>
 			<artifactId>bstats-bukkit</artifactId>
-			<version>1.2</version>
+			<version>1.5</version>
 		</dependency>
 		<dependency>
 			<groupId>com.gmail.bleedobsidian.miconomy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
@@ -66,8 +66,8 @@ Vault currently supports the following: Permissions 3, PEX, GroupManager, bPerms
 			<url>http://dev.escapecraft.com/maven</url>
 		</repository>
 		<repository>
-			<id>bstats-repo</id>
-			<url>https://repo.bstats.org/content/repositories/releases/</url>
+			<id>codemc-repo</id>
+			<url>https://repo.codemc.org/repository/maven-public</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Having that much of outdated version of bstats prevents some of the plugins to send data, which was introduced in the new versions. Since some of the data for bstats sends only when all plugins are latest bstats version, you need to update dat.

EDIT: After the 2nd commit the CI is failing not because of the commits, but because of other things which is idk. For me compiles alright