### PR TITLE
[Economy] Remove double logging plugin name

### DIFF
--- a/src/net/milkbowl/vault/economy/plugins/Economy_BOSE7.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_BOSE7.java
@@ -48,7 +48,7 @@ public class Economy_BOSE7 extends AbstractEconomy {
             Plugin bose = plugin.getServer().getPluginManager().getPlugin("BOSEconomy");
             if (bose != null && bose.isEnabled() && bose.getDescription().getVersion().startsWith("0.7")) {
                 economy = (BOSEconomy) bose;
-                log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), name));
+                log.info(String.format("[Economy] %s hooked.", name));
             }
         }
     }

--- a/src/net/milkbowl/vault/economy/plugins/Economy_BOSE7.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_BOSE7.java
@@ -134,7 +134,7 @@ public class Economy_BOSE7 extends AbstractEconomy {
 
                 if (bose.getDescription().getName().equals("BOSEconomy") && bose.getDescription().getVersion().startsWith("0.7")) {
                     economy.economy = (BOSEconomy) bose;
-                    log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s hooked.", economy.name));
                 }
             }
         }
@@ -144,7 +144,7 @@ public class Economy_BOSE7 extends AbstractEconomy {
             if (economy.economy != null) {
                 if (event.getPlugin().getDescription().getName().equals("BOSEconomy") && event.getPlugin().getDescription().getVersion().startsWith("0.7")) {
                     economy.economy = null;
-                    log.info(String.format("[%s][Economy] %s unhooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s unhooked.", economy.name));
                 }
             }
         }

--- a/src/net/milkbowl/vault/economy/plugins/Economy_CommandsEX.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_CommandsEX.java
@@ -22,7 +22,7 @@ import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 public class Economy_CommandsEX extends AbstractEconomy {
 	private final Logger log;
 	private final String name = "CommandsEX Economy";
-    private Plugin plugin = null;
+    	private Plugin plugin = null;
    	private CommandsEX economy = null;
     
 	public Economy_CommandsEX(Plugin plugin){

--- a/src/net/milkbowl/vault/economy/plugins/Economy_CommandsEX.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_CommandsEX.java
@@ -23,7 +23,7 @@ public class Economy_CommandsEX extends AbstractEconomy {
 	private final Logger log;
 	private final String name = "CommandsEX Economy";
     private Plugin plugin = null;
-    private CommandsEX economy = null;
+   	private CommandsEX economy = null;
     
 	public Economy_CommandsEX(Plugin plugin){
 		this.plugin = plugin;
@@ -35,7 +35,7 @@ public class Economy_CommandsEX extends AbstractEconomy {
             
             if (commandsex != null && commandsex.isEnabled()) {
                 economy = (CommandsEX) commandsex;
-                log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), name));
+                log.info(String.format("[Economy] %s hooked.", name));
             }
         }
 	}
@@ -54,7 +54,7 @@ public class Economy_CommandsEX extends AbstractEconomy {
 
                 if (cex.getDescription().getName().equals("CommandsEX")) {
                     economy.economy = (CommandsEX) cex;
-                    log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s hooked.", economy.name));
                 }
             }
         }
@@ -64,7 +64,7 @@ public class Economy_CommandsEX extends AbstractEconomy {
             if (economy.economy != null) {
                 if (event.getPlugin().getDescription().getName().equals("CommandsEX")) {
                     economy.economy = null;
-                    log.info(String.format("[%s][Economy] %s unhooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s unhooked.", economy.name));
                 }
             }
         }

--- a/src/net/milkbowl/vault/economy/plugins/Economy_Craftconomy3.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_Craftconomy3.java
@@ -52,7 +52,7 @@ public class Economy_Craftconomy3 extends AbstractEconomy {
 			Plugin ec = plugin.getServer().getPluginManager().getPlugin("Craftconomy3");
 			if (ec != null && ec.isEnabled() && ec.getClass().getName().equals("com.greatmancode.craftconomy3.BukkitLoader")) {
 				economy = (BukkitLoader) ec;
-				log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), name));
+				log.info(String.format("[Economy] %s hooked.", name));
 			}
 		}
 	}
@@ -71,7 +71,7 @@ public class Economy_Craftconomy3 extends AbstractEconomy {
 
 				if (ec.getDescription().getName().equals("Craftconomy3") && ec.getClass().getName().equals("com.greatmancode.craftconomy3.tools.interfaces.BukkitLoader")) {
 					economy.economy = (BukkitLoader) ec;
-					log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), economy.name));
+					log.info(String.format("[Economy] %s hooked.", economy.name));
 				}
 			}
 		}
@@ -81,7 +81,7 @@ public class Economy_Craftconomy3 extends AbstractEconomy {
 			if (economy.economy != null) {
 				if (event.getPlugin().getDescription().getName().equals("Craftconomy3")) {
 					economy.economy = null;
-					log.info(String.format("[%s][Economy] %s unhooked.", plugin.getDescription().getName(), economy.name));
+					log.info(String.format("[Economy] %s unhooked.", economy.name));
 				}
 			}
 		}

--- a/src/net/milkbowl/vault/economy/plugins/Economy_CurrencyCore.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_CurrencyCore.java
@@ -50,7 +50,7 @@ public class Economy_CurrencyCore extends AbstractEconomy {
             Plugin currencyPlugin = plugin.getServer().getPluginManager().getPlugin("CurrencyCore");
             if(currencyPlugin != null && currencyPlugin.getClass().getName().equals("is.currency.Currency")) {
                 this.currency = (Currency) currencyPlugin;
-                log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), name));  
+                log.info(String.format("[Economy] %s hooked.", name));  
             }
         }
     }
@@ -70,7 +70,7 @@ public class Economy_CurrencyCore extends AbstractEconomy {
                 
                 if(currencyPlugin.getDescription().getName().equals("CurrencyCore") && currencyPlugin.getClass().getName().equals("is.currency.Currency")) {
                     this.economy.currency = (Currency) currencyPlugin;
-                    log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), this.economy.getName()));  
+                    log.info(String.format("[Economy] %s hooked.", this.economy.getName()));  
                 }
             }
         }
@@ -80,7 +80,7 @@ public class Economy_CurrencyCore extends AbstractEconomy {
             if (this.economy.currency != null) {
                 if (event.getPlugin().getDescription().getName().equals("CurrencyCore")) {
                     this.economy.currency = null;
-                    log.info(String.format("[%s][Economy] %s unhooked.", plugin.getDescription().getName(), this.economy.getName()));
+                    log.info(String.format("[Economy] %s unhooked.", this.economy.getName()));
                 }
             }
         }

--- a/src/net/milkbowl/vault/economy/plugins/Economy_DigiCoin.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_DigiCoin.java
@@ -48,7 +48,7 @@ public class Economy_DigiCoin extends AbstractEconomy {
 
             if (digicoin != null && digicoin.isEnabled()) {
                 economy = (DigiCoin) digicoin;
-                log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), name));
+                log.info(String.format("[Economy] %s hooked.", name));
             }
         }
     }
@@ -67,7 +67,7 @@ public class Economy_DigiCoin extends AbstractEconomy {
 
                 if (digicoin.getDescription().getName().equals(economy.name)) {
                     economy.economy = (DigiCoin) digicoin;
-                    log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s hooked.", economy.name));
                 }
             }
         }
@@ -77,7 +77,7 @@ public class Economy_DigiCoin extends AbstractEconomy {
             if (economy.economy != null) {
                 if (event.getPlugin().getDescription().getName().equals(economy.name)) {
                     economy.economy = null;
-                    log.info(String.format("[%s][Economy] %s unhooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s unhooked.", economy.name));
                 }
             }
         }

--- a/src/net/milkbowl/vault/economy/plugins/Economy_EconXP.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_EconXP.java
@@ -52,7 +52,7 @@ public class Economy_EconXP extends AbstractEconomy {
             Plugin econ = plugin.getServer().getPluginManager().getPlugin("EconXP");
             if (econ != null && econ.isEnabled()) {
                 this.econ = (EconXP) econ;
-                log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), name));
+                log.info(String.format("[Economy] %s hooked.", name));
             }
         }
     }
@@ -71,7 +71,7 @@ public class Economy_EconXP extends AbstractEconomy {
 
                 if (eco.getDescription().getName().equals("EconXP")) {
                     economy.econ = (EconXP) eco;
-                    log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s hooked.", economy.name));
                 }
             }
         }
@@ -81,7 +81,7 @@ public class Economy_EconXP extends AbstractEconomy {
             if (economy.econ != null) {
                 if (event.getPlugin().getDescription().getName().equals("EconXP")) {
                     economy.econ = null;
-                    log.info(String.format("[%s][Economy] %s unhooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s unhooked.", economy.name));
                 }
             }
         }

--- a/src/net/milkbowl/vault/economy/plugins/Economy_Essentials.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_Essentials.java
@@ -52,7 +52,7 @@ public class Economy_Essentials extends AbstractEconomy {
             Plugin essentials = plugin.getServer().getPluginManager().getPlugin("Essentials");
             if (essentials != null && essentials.isEnabled()) {
                 ess = (Essentials) essentials;
-                log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), name));
+                log.info(String.format("[Economy] %s hooked.", name));
             }
         }
     }
@@ -194,7 +194,7 @@ public class Economy_Essentials extends AbstractEconomy {
 
                 if (essentials.getDescription().getName().equals("Essentials")) {
                     economy.ess = (Essentials) essentials;
-                    log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s hooked.", economy.name));
                 }
             }
         }
@@ -204,7 +204,7 @@ public class Economy_Essentials extends AbstractEconomy {
             if (economy.ess != null) {
                 if (event.getPlugin().getDescription().getName().equals("Essentials")) {
                     economy.ess = null;
-                    log.info(String.format("[%s][Economy] %s unhooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s unhooked.", economy.name));
                 }
             }
         }

--- a/src/net/milkbowl/vault/economy/plugins/Economy_GoldIsMoney2.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_GoldIsMoney2.java
@@ -48,7 +48,7 @@ public class Economy_GoldIsMoney2 extends AbstractEconomy {
 
 	        if (ec != null && ec.isEnabled() && ec.getClass().getName().equals("com.flobi.GoldIsMoney2.GoldIsMoney")) {
 	            economy = (GoldIsMoney) ec;
-	            log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), name));
+	            log.info(String.format("[Economy] %s hooked.", name));
 	        }
 	    }
 	}
@@ -268,7 +268,7 @@ public class Economy_GoldIsMoney2 extends AbstractEconomy {
 
 				if (ec.getClass().getName().equals("com.flobi.GoldIsMoney2.GoldIsMoney")) {
 					economy.economy = (GoldIsMoney) ec;
-					log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), economy.name));
+					log.info(String.format("[Economy] %s hooked.", economy.name));
 				}
 			}
 		}
@@ -278,7 +278,7 @@ public class Economy_GoldIsMoney2 extends AbstractEconomy {
 			if (economy.economy != null) {
 				if (event.getPlugin().getDescription().getName().equals("GoldIsMoney")) {
 					economy.economy = null;
-					log.info(String.format("[%s][Economy] %s unhooked.", plugin.getDescription().getName(), economy.name));
+					log.info(String.format("[Economy] %s unhooked.", economy.name));
 				}
 			}
 		}

--- a/src/net/milkbowl/vault/economy/plugins/Economy_GoldenChestEconomy.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_GoldenChestEconomy.java
@@ -48,7 +48,7 @@ public class Economy_GoldenChestEconomy extends AbstractEconomy {
             Plugin ec = plugin.getServer().getPluginManager().getPlugin("GoldenChestEconomy");
             if (ec != null && ec.isEnabled() && ec.getClass().getName().equals("me.igwb.GoldenChest.GoldenChestEconomy")) {
                 economy = (GoldenChestEconomy) ec;
-                log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), name));
+                log.info(String.format("[Economy] %s hooked.", name));
             }
         }
     }
@@ -67,7 +67,7 @@ public class Economy_GoldenChestEconomy extends AbstractEconomy {
     
                 if (ec.getDescription().getName().equals("GoldenChestEconomy") && ec.getClass().getName().equals("me.igwb.GoldenChest.GoldenChestEconomy")) {
                     economy.economy = (GoldenChestEconomy) ec;
-                    log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s hooked.", economy.name));
                 }
             }
         }
@@ -77,7 +77,7 @@ public class Economy_GoldenChestEconomy extends AbstractEconomy {
             if (economy.economy != null) {
                 if (event.getPlugin().getDescription().getName().equals("GoldenChestEconomy")) {
                     economy.economy = null;
-                    log.info(String.format("[%s][Economy] %s unhooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s unhooked.", economy.name));
                 }
             }
         }

--- a/src/net/milkbowl/vault/economy/plugins/Economy_Gringotts.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_Gringotts.java
@@ -51,7 +51,7 @@ public class Economy_Gringotts extends AbstractEconomy {
             Plugin grngts = plugin.getServer().getPluginManager().getPlugin("Gringotts");
             if (grngts != null && grngts.isEnabled()) {
                 gringotts = (Gringotts) grngts;
-                log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), name));
+                log.info(String.format("[Economy] %s hooked.", name));
             }
         }
     }
@@ -70,7 +70,7 @@ public class Economy_Gringotts extends AbstractEconomy {
 
                 if (grngts.getDescription().getName().equals("Gringotts")) {
                     economy.gringotts = (Gringotts) grngts;
-                    log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s hooked.", economy.name));
                 }
             }
         }
@@ -80,7 +80,7 @@ public class Economy_Gringotts extends AbstractEconomy {
             if (economy.gringotts != null) {
                 if (event.getPlugin().getDescription().getName().equals("Gringotts")) {
                     economy.gringotts = null;
-                    log.info(String.format("[%s][Economy] %s unhooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s unhooked.", economy.name));
                 }
             }
         }

--- a/src/net/milkbowl/vault/economy/plugins/Economy_McMoney.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_McMoney.java
@@ -50,7 +50,7 @@ public class Economy_McMoney extends AbstractEconomy {
             Plugin econ = plugin.getServer().getPluginManager().getPlugin("McMoney");
             if (econ != null && econ.isEnabled()) {
                 economy = McMoneyAPI.getInstance();
-                log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), name));
+                log.info(String.format("[Economy] %s hooked.", name));
             }
         }
     }
@@ -116,7 +116,7 @@ public class Economy_McMoney extends AbstractEconomy {
 
                 if (eco.getDescription().getName().equals("McMoney")) {
                     economy.economy = McMoneyAPI.getInstance();
-                    log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s hooked.", economy.name));
                 }
             }
         }
@@ -126,7 +126,7 @@ public class Economy_McMoney extends AbstractEconomy {
             if (economy.economy != null) {
                 if (event.getPlugin().getDescription().getName().equals("McMoney")) {
                     economy.economy = null;
-                    log.info(String.format("[%s][Economy] %s unhooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s unhooked.", economy.name));
                 }
             }
         }

--- a/src/net/milkbowl/vault/economy/plugins/Economy_MiConomy.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_MiConomy.java
@@ -56,7 +56,7 @@ public class Economy_MiConomy extends AbstractEconomy {
             if (miConomy != null) {
                 miConomy = (Main) miConomyPlugin;
                 economy = miConomy.getInstance();
-                log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), name));
+                log.info(String.format("[Economy] %s hooked.", name));
             }
         }
     }
@@ -350,7 +350,7 @@ public class Economy_MiConomy extends AbstractEconomy {
                     
                     economy.economy = miConomy.getInstance();
                     
-                    log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), name));
+                    log.info(String.format("[Economy] %s hooked.", name));
                 }
             }
         }
@@ -362,7 +362,7 @@ public class Economy_MiConomy extends AbstractEconomy {
                     economy.miConomy = null;
                     economy.economy = null;
                     
-                    log.info(String.format("[%s][Economy] %s unhooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s unhooked.", economy.name));
                 }
             }
         }

--- a/src/net/milkbowl/vault/economy/plugins/Economy_MineConomy.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_MineConomy.java
@@ -52,7 +52,7 @@ public class Economy_MineConomy extends AbstractEconomy {
             Plugin econ = plugin.getServer().getPluginManager().getPlugin("MineConomy");
             if (econ != null && econ.isEnabled()) {
                 this.econ = (MineConomy) econ;
-                log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), name));
+                log.info(String.format("[Economy] %s hooked.", name));
             }
         }
     }
@@ -71,7 +71,7 @@ public class Economy_MineConomy extends AbstractEconomy {
 
                 if (eco.getDescription().getName().equals("MineConomy")) {
                     economy.econ = (MineConomy) eco;
-                    log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s hooked.", economy.name));
                 }
             }
         }
@@ -81,7 +81,7 @@ public class Economy_MineConomy extends AbstractEconomy {
             if (economy.econ != null) {
                 if (event.getPlugin().getDescription().getName().equals("MineConomy")) {
                     economy.econ = null;
-                    log.info(String.format("[%s][Economy] %s unhooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s unhooked.", economy.name));
                 }
             }
         }

--- a/src/net/milkbowl/vault/economy/plugins/Economy_Minefaconomy.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_Minefaconomy.java
@@ -34,7 +34,7 @@ public class Economy_Minefaconomy extends AbstractEconomy {
 		}
 		if (econ != null && econ.isEnabled()) {
 			economy = (Minefaconomy) econ;
-			log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), this.name));
+			log.info(String.format("[Economy] %s hooked.", this.name));
 			return;
 		}
 		log.info("Error Loading Minefaconomy");
@@ -54,7 +54,7 @@ public class Economy_Minefaconomy extends AbstractEconomy {
 
                 if (mfc.getDescription().getName().equals("Minefaconomy")) {
                     economy_minefaconomy.economy = (Minefaconomy) economy;
-                    log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), economy_minefaconomy.name));
+                    log.info(String.format("[Economy] %s hooked.", economy_minefaconomy.name));
                 }
             }
         }
@@ -64,7 +64,7 @@ public class Economy_Minefaconomy extends AbstractEconomy {
             if (economy_minefaconomy.economy != null) {
                 if (event.getPlugin().getDescription().getName().equals("Minefaconomy")) {
                     economy_minefaconomy.economy = null;
-                    log.info(String.format("[%s][Economy] %s unhooked.", plugin.getDescription().getName(), economy_minefaconomy.name));
+                    log.info(String.format("[Economy] %s unhooked.", economy_minefaconomy.name));
                 }
             }
         }

--- a/src/net/milkbowl/vault/economy/plugins/Economy_MultiCurrency.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_MultiCurrency.java
@@ -49,7 +49,7 @@ public class Economy_MultiCurrency extends AbstractEconomy {
             Plugin multiCurrency = plugin.getServer().getPluginManager().getPlugin("MultiCurrency");
             if (multiCurrency != null && multiCurrency.isEnabled()) {
                 economy = (Currency) multiCurrency;
-                log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), name));
+                log.info(String.format("[Economy] %s hooked.", name));
             }
         }
     }
@@ -161,7 +161,7 @@ public class Economy_MultiCurrency extends AbstractEconomy {
 
                 if (mcur.getDescription().getName().equals("MultiCurrency")) {
                     economy.economy = (Currency) mcur;
-                    log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s hooked.", economy.name));
                 }
             }
         }
@@ -171,7 +171,7 @@ public class Economy_MultiCurrency extends AbstractEconomy {
             if (economy.economy != null) {
                 if (event.getPlugin().getDescription().getName().equals("MultiCurrency")) {
                     economy.economy = null;
-                    log.info(String.format("[%s][Economy] %s unhooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s unhooked.", economy.name));
                 }
             }
         }

--- a/src/net/milkbowl/vault/economy/plugins/Economy_SDFEconomy.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_SDFEconomy.java
@@ -51,7 +51,7 @@ public class Economy_SDFEconomy extends AbstractEconomy {
         SDFEconomy pluginSDF = (SDFEconomy) plugin.getServer().getPluginManager().getPlugin("SDFEconomy");
         if(!isEnabled() && pluginSDF != null) {
             api = pluginSDF.getAPI(); 
-            log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), name));
+            log.info(String.format("[Economy] %s hooked.", name));
         }
     }
 
@@ -59,7 +59,7 @@ public class Economy_SDFEconomy extends AbstractEconomy {
         SDFEconomy pluginSDF = (SDFEconomy) plugin.getServer().getPluginManager().getPlugin("SDFEconomy");
         if(isEnabled() && pluginSDF != null) {
             api = null; 
-            log.info(String.format("[%s][Economy] %s unhooked.", plugin.getDescription().getName(), name));
+            log.info(String.format("[Economy] %s unhooked.", name));
         }
     }
 

--- a/src/net/milkbowl/vault/economy/plugins/Economy_TAEcon.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_TAEcon.java
@@ -48,7 +48,7 @@ public class Economy_TAEcon extends AbstractEconomy {
             
             if (taecon != null && taecon.isEnabled()) {
                 economy = (TAEcon) taecon;
-                log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), name));
+                log.info(String.format("[Economy] %s hooked.", name));
             }
         }
 	}
@@ -67,7 +67,7 @@ public class Economy_TAEcon extends AbstractEconomy {
 
                 if (taecon.getDescription().getName().equals(economy.name)) {
                     economy.economy = (TAEcon) taecon;
-                    log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s hooked.", economy.name));
                 }
             }
         }
@@ -77,7 +77,7 @@ public class Economy_TAEcon extends AbstractEconomy {
             if (economy.economy != null) {
                 if (event.getPlugin().getDescription().getName().equals(economy.name)) {
                     economy.economy = null;
-                    log.info(String.format("[%s][Economy] %s unhooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s unhooked.", economy.name));
                 }
             }
         }

--- a/src/net/milkbowl/vault/economy/plugins/Economy_XPBank.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_XPBank.java
@@ -55,7 +55,7 @@ public class Economy_XPBank extends AbstractEconomy {
             if (economy != null && economy.isEnabled()) {
                 XPB = (XPBank) economy;
                 api = XPB.getAPI();
-                log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), name));
+                log.info(String.format("[Economy] %s hooked.", name));
             }
         }
     }
@@ -75,7 +75,7 @@ public class Economy_XPBank extends AbstractEconomy {
                 if (eco.getDescription().getName().equals("XPBank")) {
                     economy.XPB = (XPBank) eco;
                     api = XPB.getAPI();
-                    log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s hooked.", economy.name));
                 }
             }
         }
@@ -85,7 +85,7 @@ public class Economy_XPBank extends AbstractEconomy {
             if (economy.XPB != null) {
                 if (event.getPlugin().getDescription().getName().equals("XPBank")) {
                     economy.XPB = null;
-                    log.info(String.format("[%s][Economy] %s unhooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s unhooked.", economy.name));
                 }
             }
         }

--- a/src/net/milkbowl/vault/economy/plugins/Economy_eWallet.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_eWallet.java
@@ -49,7 +49,7 @@ public class Economy_eWallet extends AbstractEconomy {
             Plugin econ = plugin.getServer().getPluginManager().getPlugin("eWallet");
             if (econ != null && econ.isEnabled()) {
                 this.econ = (ECO) econ;
-                log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), name));
+                log.info(String.format("[Economy] %s hooked.", name));
             }
         }
     }
@@ -68,7 +68,7 @@ public class Economy_eWallet extends AbstractEconomy {
 
                 if (eco.getDescription().getName().equals("eWallet")) {
                     economy.econ = (ECO) eco;
-                    log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s hooked.", economy.name));
                 }
             }
         }
@@ -78,7 +78,7 @@ public class Economy_eWallet extends AbstractEconomy {
             if (economy.econ != null) {
                 if (event.getPlugin().getDescription().getName().equals("eWallet")) {
                     economy.econ = null;
-                    log.info(String.format("[%s][Economy] %s unhooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s unhooked.", economy.name));
                 }
             }
         }

--- a/src/net/milkbowl/vault/economy/plugins/Economy_iConomy6.java
+++ b/src/net/milkbowl/vault/economy/plugins/Economy_iConomy6.java
@@ -58,7 +58,7 @@ public class Economy_iConomy6 extends AbstractEconomy {
                 name += version;
                 economy = (iConomy) ec;
                 accounts = new Accounts();
-                log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), name));
+                log.info(String.format("[Economy] %s hooked.", name));
             }
         }
     }
@@ -79,7 +79,7 @@ public class Economy_iConomy6 extends AbstractEconomy {
                     name += version;
                     economy.economy = (iConomy) ec;
                     accounts = new Accounts();
-                    log.info(String.format("[%s][Economy] %s hooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s hooked.", economy.name));
                 }
             }
         }
@@ -89,7 +89,7 @@ public class Economy_iConomy6 extends AbstractEconomy {
             if (economy.economy != null) {
                 if (event.getPlugin().getDescription().getName().equals("iConomy")) {
                     economy.economy = null;
-                    log.info(String.format("[%s][Economy] %s unhooked.", plugin.getDescription().getName(), economy.name));
+                    log.info(String.format("[Economy] %s unhooked.", economy.name));
                 }
             }
         }


### PR DESCRIPTION
![kép](https://user-images.githubusercontent.com/30026208/60118825-656f2600-977d-11e9-83d6-2864ba105b50.png)
As shown in the picture, it has been tested with Essentials, but I think it is the same for other plugins, so we don't have to double the plugin name in the console.