### PR TITLE
Added correct permissions to all registered commands in plugins.yml

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -13,10 +13,12 @@ commands:
     description: Displays information about Vault 
     usage: |
            /<command> - Displays Vault information
+    permission: vault.admin
   vault-convert:
     description: Converts all data in economy1 and dumps it into economy2
     usage: |
            /<command> [economy1] [economy2]
+    permission: vault.admin
 permissions:
   vault.admin:
     description: Notifies the player when vault is in need of an update.


### PR DESCRIPTION
Added the permissions to the registered commands "/vault-convert" and "/vault-info" in plugin.yml so spigot will know not to include those commands in the command suggestions of players who don't have the "vault.admin" permission.