### PR TITLE
Add option to silence "no update" logs

### DIFF
--- a/src/net/milkbowl/vault/Vault.java
+++ b/src/net/milkbowl/vault/Vault.java
@@ -132,6 +132,7 @@ public class Vault extends JavaPlugin {
         sm = getServer().getServicesManager();
         // set defaults
         getConfig().addDefault("update-check", true);
+        getConfig().addDefault("silent-no-update", false);
         getConfig().options().copyDefaults(true);
         saveConfig();
         // Load Vault Addons

--- a/src/net/milkbowl/vault/Vault.java
+++ b/src/net/milkbowl/vault/Vault.java
@@ -172,7 +172,8 @@ public class Vault extends JavaPlugin {
                                 } else if (currentVersion > newVersion) {
                                     log.info("Stable Version: " + newVersionTitle + " | Current Version: " + currentVersionTitle);
                                 } else {
-                                    log.info("No new version available");
+                                    if (!getConfig().getBoolean("silent-no-update", false))
+                                        log.info("No new version available");
                                 }
                             } catch (Exception e) {
                                 // ignore exceptions

--- a/src/net/milkbowl/vault/Vault.java
+++ b/src/net/milkbowl/vault/Vault.java
@@ -132,7 +132,6 @@ public class Vault extends JavaPlugin {
         sm = getServer().getServicesManager();
         // set defaults
         getConfig().addDefault("update-check", true);
-        getConfig().addDefault("silent-no-update", false);
         getConfig().options().copyDefaults(true);
         saveConfig();
         // Load Vault Addons
@@ -172,9 +171,6 @@ public class Vault extends JavaPlugin {
                                     log.warning("Update at: https://dev.bukkit.org/projects/vault");
                                 } else if (currentVersion > newVersion) {
                                     log.info("Stable Version: " + newVersionTitle + " | Current Version: " + currentVersionTitle);
-                                } else {
-                                    if (!getConfig().getBoolean("silent-no-update", false))
-                                        log.info("No new version available");
                                 }
                             } catch (Exception e) {
                                 // ignore exceptions
@@ -184,7 +180,6 @@ public class Vault extends JavaPlugin {
                 }, 0, 432000);
 
             }
-
         });
 
         // Load up the Plugin metrics


### PR DESCRIPTION
As a server maintainer, I find these log messages are simply cramming the log files with uneccessary junk. This addition doesn't change the default behaviour at all. It just gives me - and potentially other admins - an option to disable the output while still getting messages for new updates.