### PR TITLE
build: use travis for config for conditionals instead of scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,16 @@ env:
   global:
     - secure: "WGObsHmjnqn5e0nbXLGetwpUHU0UgvNk02+f0m3jIS7hSdBy5m1JK2K6NXV13brY0C9i0DLy0e7JKabqmqTxI94dT0LrYBxcvfmtZ/7PujOn/D9CzVimGj6g20hBDYwAXL6KAIR7JL8qexQBwIkVZPdwaA+k+UHLM9XVoIQdFgU="
     - secure: "XfBov3Z4Rk2AvS1v7o31Qr2XrO/oqQvl+Eksx9DO3XbGcLjT9wfGxGcYgP9IJO+Aa5AQo3Xud7EV4gqNpMa2PByzDdgg/nfyqSvrRvsG2aH1zm5N5bAHxCVlPimVdNtyeub6QBPCIGaWBp1R8x3Ak7F79mA5BdJuT9j5FBogC5U="
-script: .utility/do-build.sh
+
+deploy:
+  - provider: script
+    script: .utility/build.sh
+    on:
+      all_branches: true
+  - provider: script
+    script: .utility/deploy.sh
+    on:
+      branch: master
 
 cache:
   directories:

--- a/.utility/build.sh
+++ b/.utility/build.sh
@@ -4,11 +4,5 @@ then
         echo 'Travis can only publish docs for release builds.'
         return 0
 fi
-if [[ $TRAVIS_PULL_REQUEST == true || "$TRAVIS_BRANCH" != "master" ]]
-then
-	mvn test
-else
-	mvn clean deploy --settings .utility/settings.xml
-fi
-
+mvn test
 exit $?

--- a/.utility/deploy.sh
+++ b/.utility/deploy.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [[ "$TRAVIS_REPO_SLUG" != "MilkBowl/Vault" ]]
+then
+        echo 'Travis can only publish docs for release builds.'
+        return 0
+fi
+mvn clean deploy --settings .utility/settings.xml
+exit $?


### PR DESCRIPTION
Seems like we always perform the deploy step during PR's, in this new configuration we should only do the deploy steps from master branch by using the travis configuration instead of the script checking environment variables.