### PR TITLE
Fix null in square brackets in /vault-info

### DIFF
--- a/src/net/milkbowl/vault/Vault.java
+++ b/src/net/milkbowl/vault/Vault.java
@@ -416,9 +416,9 @@ public class Vault extends JavaPlugin {
         }
         // Send user some info!
         sender.sendMessage(String.format("[%s] Vault v%s Information", getDescription().getName(), getDescription().getVersion()));
-        sender.sendMessage(String.format("[%s] Economy: %s [%s]", getDescription().getName(), econ == null ? "None" : econ.getName(), registeredEcons));
-        sender.sendMessage(String.format("[%s] Permission: %s [%s]", getDescription().getName(), perm == null ? "None" : perm.getName(), registeredPerms));
-        sender.sendMessage(String.format("[%s] Chat: %s [%s]", getDescription().getName(), chat == null ? "None" : chat.getName(), registeredChats));
+        sender.sendMessage(String.format("[%s] Economy: %s%s", getDescription().getName(), econ == null ? "None" : econ.getName(), registeredEcons == null ? "" : " [" + registeredEcons + "]"));
+        sender.sendMessage(String.format("[%s] Permission: %s%s", getDescription().getName(), perm == null ? "None" : perm.getName(), registeredPerms == null ? "" : " [" + registeredPerms + "]"));
+        sender.sendMessage(String.format("[%s] Chat: %s%s", getDescription().getName(), chat == null ? "None" : chat.getName(), registeredChats == null ? "" : " [" + registeredChats + "]"));
     }
 
     /**


### PR DESCRIPTION
When there are no plugins for economy, permissions and chat, this is the output of the /vault-info command:
```
[Vault] Economy: None [null]
[Vault] Permission: SuperPerms [SuperPerms]
[Vault] Chat: None [null]
```
Now:
```
[Vault] Economy: None
[Vault] Permission: SuperPerms [SuperPerms]
[Vault] Chat: None
```