### PR TITLE
Add more permission nodes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ So, what features do I _think_ you'll like the most?
 
 ## Permissions
 * vault.admin
-  - Determines if a player should receive the update notices
+  - Determines if a player should have access to the administrative tools.
+* vault.update
+  - Determines if a player should receive the update notices.
 
 ## License
 Copyright (C) 2011-2018 Morgan Humes <morgan@lanaddict.com>

--- a/plugin.yml
+++ b/plugin.yml
@@ -10,16 +10,22 @@ load: startup
 
 commands:
   vault-info:
-    description: Displays information about Vault 
+    description: Displays information about Vault.
     usage: |
            /<command> - Displays Vault information
-    permission: vault.admin
+    permission: vault.admin.info
   vault-convert:
-    description: Converts all data in economy1 and dumps it into economy2
+    description: Converts the specified economy to another format.
     usage: |
            /<command> [economy1] [economy2]
-    permission: vault.admin
+    permission: vault.admin.convert
 permissions:
   vault.admin:
-    description: Notifies the player when vault is in need of an update.
+    description: Allows using the administrative tools for Vault.
+    default: op
+    children:
+      vault.admin.info: true
+      vault.admin.convert: true
+  vault.update:
+    description: Notifies the player when Vault is in need of an update.
     default: op

--- a/src/net/milkbowl/vault/Vault.java
+++ b/src/net/milkbowl/vault/Vault.java
@@ -294,11 +294,23 @@ public class Vault extends JavaPlugin {
         }
 
         if (command.getName().equalsIgnoreCase("vault-info")) {
+          if (!sender.hasPermission("vault.admin.info")) {
+              sender.sendMessage("You do not have permission to use that command!");
+              return true;
+          }
+          else {
             infoCommand(sender);
             return true;
+          }
         } else if (command.getName().equalsIgnoreCase("vault-convert")) {
+          if (!sender.hasPermission("vault.admin.convert")) {
+              sender.sendMessage("You do not have permission to use that command!");
+              return true;
+          }
+          else {
             convertCommand(sender, args);
             return true;
+          }
         } else {
             // Show help
             sender.sendMessage("Vault Commands:");


### PR DESCRIPTION
This pull request adds more permission nodes for Vault. This is designed to grant more control over what administrative tools a player can use.

By default, the "vault.admin" node grants access to everything. However, access to certain tools can be disabled by negatating the required node (for example, if you want someone to have access to "/vault-info" but not "/vault-convert", you could negatate the "vault.admin.convert" node).